### PR TITLE
Refactor subprocess timeout; remove --sudo

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -25,16 +25,24 @@ Installation
 Usage
 -----
 
-Return gluster stats in json format.
+Return gluster stats in json format. Requires root privileges.
 
-``sudo gluster-stats``
+Options::
 
-Alternatively, use ``gluster-stats --sudo`` to have gluster-stats call all of
-the gluster commands with sudo, instead of calling gluster-stats root access
-itself.
+    $ gluster-stats --help
+    usage: gluster-stats [-h] [--record] [--version] [--timeout TIMEOUT]
+
+    Collect stats related to gluster
+
+    optional arguments:
+      -h, --help         show this help message and exit
+      --record           Record the gluster cli responses in a local response file
+      --version          show program's version number and exit
+      --timeout TIMEOUT  Timeout per command in seconds. Defaults to 300.
 
 Example output::
 
+    $ sudo gluster-stats
     {
      "brick_stats": {
       "preprodcomms": [

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
     package_dir={'gluster_stats':
                  'gluster_stats'},
     include_package_data=True,
-    install_requires=['easyprocess', 'future'],
+    install_requires=['future'],
     license="BSD",
     keywords='gluster monitoring',
     classifiers=[


### PR DESCRIPTION
- Eliminate dependency on easyprocess
- Implement process tree kill, otherwise 'glfsheal' processes don't get
  killed
- Eliminate --sudo option. Rather pointless, and doesn't work with
  os.kill/os.killpg.
